### PR TITLE
Added basic JIT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,18 @@ find_package(LLVM CONFIG REQUIRED)
 find_package(Swift CONFIG REQUIRED)
 find_package(Clang CONFIG REQUIRED)
 
-add_executable(swift-repl main.cpp REPL.cpp)
+add_executable(swift-repl main.cpp REPL.cpp JIT.cpp)
 target_include_directories(swift-repl PRIVATE ${SWIFT_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})
-target_link_libraries(swift-repl PRIVATE swiftAST swiftBasic swiftFrontend swiftImmediate swiftParse swiftParseSIL swiftSema swiftSIL swiftSyntax swiftSyntaxParse)
+target_link_libraries(swift-repl PRIVATE
+  LLVMExecutionEngine
+  LLVMOrcJIT
+  swiftAST
+  swiftBasic
+  swiftFrontend
+  swiftImmediate
+  swiftParse
+  swiftParseSIL
+  swiftSema
+  swiftSIL
+  swiftSyntax
+  swiftSyntaxParse)

--- a/JIT.cpp
+++ b/JIT.cpp
@@ -1,0 +1,43 @@
+#include "JIT.h"
+
+llvm::Expected<std::unique_ptr<JIT>> JIT::Create()
+{
+    auto machine_builder = orc::JITTargetMachineBuilder::detectHost();
+    if(!machine_builder)
+        return machine_builder.takeError();
+    
+    auto data_layout = machine_builder->getDefaultDataLayoutForTarget();
+    if(!data_layout)
+        return data_layout.takeError();
+    
+    return std::unique_ptr<JIT>(new JIT(std::move(*machine_builder), std::move(*data_layout)));
+}
+
+llvm::Error JIT::AddModule(std::unique_ptr<llvm::Module> module)
+{
+    return m_compile_layer.add(m_execution_session.getMainJITDylib(),
+                               orc::ThreadSafeModule(std::move(module), m_ctx));
+}
+
+llvm::Expected<llvm::JITEvaluatedSymbol> JIT::LookupSymbol(llvm::StringRef symbol_name)
+{
+    return m_execution_session.lookup({ &m_execution_session.getMainJITDylib() },
+                                      m_mangler(symbol_name.str()));
+}
+
+JIT::JIT(orc::JITTargetMachineBuilder machine_builder,
+         llvm::DataLayout data_layout) : m_object_layer(m_execution_session,
+                                                        []() { return std::make_unique<llvm::SectionMemoryManager>(); }),
+                                         m_compile_layer(m_execution_session,
+                                                         m_object_layer,
+                                                         orc::ConcurrentIRCompiler(std::move(machine_builder))),
+                                         m_data_layout(std::move(data_layout)),
+                                         m_mangler(m_execution_session, m_data_layout),
+                                         m_ctx(std::make_unique<llvm::LLVMContext>())
+{
+    m_execution_session.getMainJITDylib().setGenerator(
+        llvm::cantFail(orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(data_layout)));
+}
+
+
+

--- a/JIT.h
+++ b/JIT.h
@@ -1,0 +1,33 @@
+#ifndef JIT_H
+#define JIT_H
+
+#include <llvm/ExecutionEngine/JITSymbol.h>
+#include <llvm/ExecutionEngine/SectionMemoryManager.h>
+#include <llvm/ExecutionEngine/Orc/CompileUtils.h>
+#include <llvm/ExecutionEngine/Orc/Core.h>
+#include <llvm/ExecutionEngine/Orc/ExecutionUtils.h>
+#include <llvm/ExecutionEngine/Orc/IRCompileLayer.h>
+#include <llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h>
+#include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h>
+
+namespace orc = llvm::orc;
+
+class JIT
+{
+public:
+    static llvm::Expected<std::unique_ptr<JIT>> Create();
+    llvm::Error AddModule(std::unique_ptr<llvm::Module> module);
+    llvm::Expected<llvm::JITEvaluatedSymbol> LookupSymbol(llvm::StringRef symbol_name);
+
+private:
+    JIT(orc::JITTargetMachineBuilder machine_builder, llvm::DataLayout data_layout);
+
+    orc::ExecutionSession m_execution_session;
+    orc::RTDyldObjectLinkingLayer m_object_layer;
+    orc::IRCompileLayer m_compile_layer;
+
+    llvm::DataLayout m_data_layout;
+    orc::MangleAndInterner m_mangler;
+    orc::ThreadSafeContext m_ctx;
+};
+#endif

--- a/REPL.h
+++ b/REPL.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef REPL_H
+#define REPL_H
 
 #include <iostream>
 #include <string>
@@ -69,3 +70,4 @@ private:
 
     std::unique_ptr<swift::ASTContext> m_ast_ctx;
 };
+#endif


### PR DESCRIPTION
Basic JIT taken from https://llvm.org/docs/tutorial/BuildingAJIT1.html

Has two functions: 
`AddModule` adds an LLVM module to the JIT and compiles it. 
`LookupSymbol` looks up a symbol in the modules. An example use case would be looking up the symbol `main` in the JIT, which will return a function pointer to the main, which you can then run. 