### PR TITLE
Logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,9 @@ add_executable(swift-repl
   main.cpp
   REPL.cpp
   JIT.cpp
-  TransformAST.cpp)
+  TransformAST.cpp
+  CommandLineOptions.cpp
+  Logging.cpp)
 target_include_directories(swift-repl PRIVATE ${SWIFT_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})
 target_link_libraries(swift-repl PRIVATE
   LLVMExecutionEngine

--- a/CommandLineOptions.cpp
+++ b/CommandLineOptions.cpp
@@ -53,9 +53,11 @@ void ParseSingleCommandLineOption(std::string arg, CommandLineOptions &opts)
     llvm::StringSwitch<OptionParseFn>(opt)
         .Case("--logging", SetLoggingAreaOption)
         .Case("--logging_priority", SetLoggingPriorityOption)
+        .Default(HandleUnknownOption)
         (opt, val, opts);
 }
 
+//TODO(sasha): Make these show no logging by default in the future.
 void SetupDefaultsIfUninitialized(CommandLineOptions &opts)
 {
     if(opts.logging_opts.log_areas == LoggingArea::Unknown)

--- a/CommandLineOptions.cpp
+++ b/CommandLineOptions.cpp
@@ -1,0 +1,77 @@
+#include "CommandLineOptions.h"
+
+#include <iostream>
+#include <string>
+#include <type_traits>
+
+#include <llvm/ADT/StringSwitch.h>
+
+void HandleUnknownOption(std::string opt, std::string val, CommandLineOptions &opts)
+{
+    // We format this manually to look like the Logging system because Logging system isn't initialized yet. 
+    std::cout << "[Warning] Ignoring unrecognized parameter \"" << opt << "\" with value " << val << "\n";
+}
+
+void SetLoggingAreaOption(std::string opt, std::string val, CommandLineOptions &opts)
+{
+    auto area = llvm::StringSwitch<LoggingArea>(val)
+        .Case(     "ast", LoggingArea::AST)
+        .Case(     "sil", LoggingArea::SIL)
+        .Case(      "ir", LoggingArea:: IR)
+        .Case(     "jit", LoggingArea::JIT)
+        .Case("importer", LoggingArea::Importer)
+        .Case(     "all", LoggingArea::All)
+        .Default(LoggingArea::Unknown);
+
+    if(area == LoggingArea::Unknown)
+        std::cout << "[Warning] Ignoring unrecognized logging area \"" << val << "\n";
+    else
+        opts.logging_opts.log_areas |= area;
+}
+
+void SetLoggingPriorityOption(std::string opt, std::string val, CommandLineOptions &opts)
+{
+    auto priority = llvm::StringSwitch<LoggingPriority>(val)
+        .Case("info", LoggingPriority::Info)
+        .Case("warning", LoggingPriority::Warning)
+        .Case("error", LoggingPriority::Error)
+        .Case("none", LoggingPriority::None)
+        .Default(LoggingPriority::Unknown);
+    
+    if(priority == LoggingPriority::Unknown)
+        std::cout << "[Warning] Ignoring unrecognized logging priority \"" << val << "\n";
+    else
+        opts.logging_opts.min_priority = priority;
+}
+
+void ParseSingleCommandLineOption(std::string arg, CommandLineOptions &opts)
+{
+    using OptionParseFn = std::add_pointer<void(std::string, std::string, CommandLineOptions &)>::type;
+    auto delimeter_pos = arg.find("=");
+    std::string opt = arg.substr(0, delimeter_pos);
+    std::string val = arg.substr(delimeter_pos + 1, arg.size() - opt.size() - 1);
+    llvm::StringSwitch<OptionParseFn>(opt)
+        .Case("--logging", SetLoggingAreaOption)
+        .Case("--logging_priority", SetLoggingPriorityOption)
+        (opt, val, opts);
+}
+
+void SetupDefaultsIfUninitialized(CommandLineOptions &opts)
+{
+    if(opts.logging_opts.log_areas == LoggingArea::Unknown)
+        opts.logging_opts.log_areas = LoggingArea::All;
+
+    if(opts.logging_opts.min_priority == LoggingPriority::Unknown)
+        opts.logging_opts.min_priority = LoggingPriority::Info;
+}
+
+CommandLineOptions ParseCommandLineOptions(int argc, char **argv)
+{
+    CommandLineOptions result;
+    for(int i = 1; i < argc; i++)
+    {
+        ParseSingleCommandLineOption(argv[i], result);
+    }
+    SetupDefaultsIfUninitialized(result);
+    return result;
+}

--- a/CommandLineOptions.h
+++ b/CommandLineOptions.h
@@ -1,0 +1,13 @@
+#ifndef COMMAND_LINE_OPTIONS_H
+#define COMMAND_LINE_OPTIONS_H
+
+#include "Logging.h"
+
+struct CommandLineOptions
+{
+    LoggingOptions logging_opts;
+};
+
+CommandLineOptions ParseCommandLineOptions(int argc, char **argv);
+
+#endif

--- a/Logging.cpp
+++ b/Logging.cpp
@@ -31,6 +31,11 @@ LoggingArea g_curr_logging_area;
 
 const char *PriorityStrings[] = { "", "[INFO] ", "[WARNING ]", "[ERROR] " };
 
+void SetLoggingOptions(LoggingOptions opts)
+{
+    g_log_opts = opts;
+}
+
 void Log(std::string message, LoggingPriority priority)
 {
     if(!ShouldLog(priority))
@@ -48,9 +53,4 @@ bool ShouldLog(LoggingPriority priority)
 void SetCurrentLoggingArea(LoggingArea area)
 {
     g_curr_logging_area = area;
-}
-
-void SetLoggingOptions(LoggingOptions opts)
-{
-    g_log_opts = opts;
 }

--- a/Logging.cpp
+++ b/Logging.cpp
@@ -1,0 +1,56 @@
+#include "Logging.h"
+
+#include <iostream>
+
+LoggingArea operator &(LoggingArea l, LoggingArea r)
+{
+    return static_cast<LoggingArea>(static_cast<uint64_t>(l) &
+                                    static_cast<uint64_t>(r));
+}
+
+LoggingArea operator |(LoggingArea l, LoggingArea r)
+{
+    return static_cast<LoggingArea>(static_cast<uint64_t>(l) |
+                                    static_cast<uint64_t>(r));
+}
+
+LoggingArea &operator &=(LoggingArea &l, LoggingArea r)
+{
+    l = l & r;
+    return l;
+}
+
+LoggingArea &operator |=(LoggingArea &l, LoggingArea r)
+{
+    l = l | r;
+    return l;
+}
+
+LoggingOptions g_log_opts;
+LoggingArea g_curr_logging_area;
+
+const char *PriorityStrings[] = { "", "[INFO] ", "[WARNING ]", "[ERROR] " };
+
+void Log(std::string message, LoggingPriority priority)
+{
+    if(!ShouldLog(priority))
+        return;
+    
+    std::cout << PriorityStrings[static_cast<uint64_t>(priority)] << message << "\n";
+}
+
+bool ShouldLog(LoggingPriority priority)
+{
+    return (g_log_opts.min_priority <= priority && priority < LoggingPriority::None) &&
+                                    (static_cast<uint64_t>(g_log_opts.log_areas) & static_cast<uint64_t>(g_curr_logging_area));
+}
+
+void SetCurrentLoggingArea(LoggingArea area)
+{
+    g_curr_logging_area = area;
+}
+
+void SetLoggingOptions(LoggingOptions opts)
+{
+    g_log_opts = opts;
+}

--- a/Logging.h
+++ b/Logging.h
@@ -43,9 +43,9 @@ struct LoggingOptions
     LoggingPriority min_priority = LoggingPriority::Unknown;
 };
 
+void SetLoggingOptions(LoggingOptions opts);
 void Log(std::string message, LoggingPriority priority = LoggingPriority::Info);
 bool ShouldLog(LoggingPriority priority = LoggingPriority::Error);
 void SetCurrentLoggingArea(LoggingArea area);
-void SetLoggingOptions(LoggingOptions opts);
 
 #endif

--- a/Logging.h
+++ b/Logging.h
@@ -1,0 +1,51 @@
+#ifndef LOGGING_H
+#define LOGGING_H
+
+#include <cstdint>
+#include <string>
+
+// To use this logging system:
+//  - Set it up by settings bits corresponding to the
+//    areas you want to log and set the maximal priority
+//    of the logs
+//  - When entering a new segment of code, SetCurrentLoggingArea()
+//    to the area corresponding to that segment
+//  - Log with Log()
+
+enum class LoggingArea : uint64_t
+{
+    Unknown = 0, 
+    AST = (1 << 0),
+    SIL = (1 << 1),
+    IR  = (1 << 2),
+    JIT = (1 << 3),
+    Importer = (1 << 4),
+    All = ~0,
+};
+
+enum class LoggingPriority : uint64_t
+{
+    Info,
+    Warning,
+    Error,
+    None,
+    Unknown,
+};
+
+LoggingArea operator &(LoggingArea l, LoggingArea r);
+LoggingArea operator |(LoggingArea l, LoggingArea r);
+LoggingArea &operator &=(LoggingArea &l, LoggingArea r);
+LoggingArea &operator |=(LoggingArea &l, LoggingArea r);
+
+struct LoggingOptions
+{
+    LoggingArea log_areas = LoggingArea::Unknown;
+    LoggingPriority min_priority = LoggingPriority::Unknown;
+};
+
+void Log(std::string message, LoggingPriority priority = LoggingPriority::Info);
+bool ShouldLog(LoggingPriority priority = LoggingPriority::Error);
+void SetCurrentLoggingArea(LoggingArea area);
+void SetLoggingOptions(LoggingOptions opts);
+
+#endif

--- a/REPL.cpp
+++ b/REPL.cpp
@@ -1,14 +1,16 @@
 #include "REPL.h"
+#include "Logging.h"
 #include "TransformAST.h"
 
 #define SWIFT_MODULE_PATH "S:\\b\\swift\\lib\\swift\\windows\\x86_64"
 
 void ConfigureFunctionLinkage(std::unique_ptr<swift::SILModule> &sil_module)
 {
+    SetCurrentLoggingArea(LoggingArea::SIL);
     for(auto &fn : sil_module->getFunctionList())
     {
         fn.setLinkage(swift::SILLinkage::Public);
-        std::cout << "Set SIL Function " << fn.getName().str() << " to public\n";
+        Log(std::string("Set SIL Function " + fn.getName().str() + " to public"));
     }
 
     sil_module->lookUpFunction("main")->setLinkage(swift::SILLinkage::Private);
@@ -26,7 +28,7 @@ REPL::REPL() : m_diagnostic_engine(m_src_mgr),
         INITIALIZE_LLVM();
         s_run_guard = true;
     }
-    
+
     m_diagnostic_engine.setShowDiagnosticsAfterFatalError();
     m_diagnostic_engine.addConsumer(m_diagnostic_consumer);
 
@@ -45,6 +47,8 @@ bool REPL::IsExitString(const std::string &line)
 
 bool REPL::ExecuteSwift(std::string line)
 {
+    //NOTE(sasha): We don't use the normal logging system here because the
+    //             DiagnosticEngine will show have showed the error.
 #define CHECK_ERROR() if(m_diagnostic_engine.hadAnyError()) { return true; }
     m_diagnostic_engine.resetHadAnyError();
 
@@ -81,8 +85,12 @@ bool REPL::ExecuteSwift(std::string line)
                                    false /* DelayBodyParsing */);
         CHECK_ERROR();
     } while(!done);
-    std::cout << "=========AST==========\n";
-    src_file->dump();
+    SetCurrentLoggingArea(LoggingArea::AST);
+    if(ShouldLog(LoggingPriority::Info))
+    {
+        std::cout << "=========AST Before Modifications==========\n";
+        src_file->dump();
+    }
     
     //TODO(sasha): Load DLLs
     swift::performNameBinding(*src_file);
@@ -93,26 +101,29 @@ bool REPL::ExecuteSwift(std::string line)
     
     ModifyAST(*src_file);
     
-    std::cout << "=========AST==========\n";
-    src_file->dump();
-
     //TODO(sasha): Perform playground transform?
     CHECK_ERROR();
     swift::typeCheckExternalDefinitions(*src_file);
     CHECK_ERROR();
     //TODO(sasha): Remember variables from previous expressions?
 
-    std::cout << "=========AST==========\n";
-    src_file->dump();
+    if(ShouldLog(LoggingPriority::Info))
+    {
+        std::cout << "=========AST After Modification==========\n";
+        src_file->dump();
+    }
     
     std::unique_ptr<swift::SILModule> sil_module(
         swift::performSILGeneration(*src_file,
                                     m_invocation.getSILOptions()));
 
     ConfigureFunctionLinkage(sil_module);
-    
-    std::cout << "=========SIL==========\n";
-    sil_module->dump();
+    SetCurrentLoggingArea(LoggingArea::SIL);
+    if(ShouldLog(LoggingPriority::Info))
+    {
+        std::cout << "=========SIL==========\n";
+        sil_module->dump();
+    }
     
     std::unique_ptr<llvm::Module> llvm_module(swift::performIRGeneration(m_invocation.getIRGenOptions(),
                                                                          *src_file,
@@ -120,13 +131,16 @@ bool REPL::ExecuteSwift(std::string line)
                                                                          "swift_repl_module",
                                                                          swift::PrimarySpecificPaths("", input.module_name),
                                                                          m_llvm_ctx));
-    std::cout << "=========LLVM IR==========\n";
-    std::string llvm_ir;
-    llvm::raw_string_ostream str_stream(llvm_ir);
-    llvm_module->print(str_stream, nullptr);
-    str_stream.flush();
-    std::cout << llvm_ir << std::endl;
-
+    SetCurrentLoggingArea(LoggingArea::IR);
+    if(ShouldLog(LoggingPriority::Info))
+    {
+        std::cout << "=========LLVM IR==========\n";
+        std::string llvm_ir;
+        llvm::raw_string_ostream str_stream(llvm_ir);
+        llvm_module->print(str_stream, nullptr);
+        str_stream.flush();
+        std::cout << llvm_ir << std::endl;
+    }
     return true;
 #undef CHECK_ERROR
 }
@@ -195,6 +209,7 @@ void REPL::SetupIROpts()
 
 void REPL::SetupImporters()
 {
+    SetCurrentLoggingArea(LoggingArea::Importer);
     swift::DependencyTracker *tracker = nullptr;
     std::string module_cache_path;
     swift::ClangImporterOptions &clang_importer_opts =
@@ -206,13 +221,13 @@ void REPL::SetupImporters()
         clang_importer = swift::ClangImporter::create(*m_ast_ctx, clang_importer_opts);
         if(!clang_importer)
         {
-            std::cout << "Failed to create ClangImporter" << std::endl;
+            Log("Failed to create ClangImporter", LoggingPriority::Error);
         }
         else
         {
             clang_importer->addSearchPath("S:\\b\\swift\\lib\\swift\\shims", /* isFramework */ false, /* ifSystem */ true);
             module_cache_path = swift::getModuleCachePathFromClang(clang_importer->getClangInstance());
-            std::cout << module_cache_path << std::endl;
+            Log("Module Cache Path: " + module_cache_path);
         }
     }
     if(module_cache_path.empty())
@@ -235,12 +250,12 @@ void REPL::SetupImporters()
     if(stdlib_buffer)
         memory_buffer_loader->registerMemoryBuffer("Swift", std::move(stdlib_buffer.get()));
     else
-        std::cerr << "Failed to load module Swift\n";
+        Log("Failed to load module Swift", LoggingPriority::Error);
 
     if(memory_buffer_loader)
         m_ast_ctx->addModuleLoader(std::move(memory_buffer_loader));
     else
-        std::cout << "Memory buffer loader failed\n";
+        Log("Failed to load module Swift", LoggingPriority::Error);
 
     if(loading_mode != swift::ModuleLoadingMode::OnlySerialized)
     {

--- a/REPL.cpp
+++ b/REPL.cpp
@@ -45,7 +45,7 @@ bool REPL::IsExitString(const std::string &line)
 
 bool REPL::ExecuteSwift(std::string line)
 {
-#define CHECK_ERROR() if(m_diagnostic_engine.hadAnyError()) { std::cout << "Error occured. Exiting." << std::endl; return true; }
+#define CHECK_ERROR() if(m_diagnostic_engine.hadAnyError()) { return true; }
     m_diagnostic_engine.resetHadAnyError();
 
     if(IsExitString(line))

--- a/REPL.h
+++ b/REPL.h
@@ -52,11 +52,13 @@ private:
                               const swift::DiagnosticInfo &info,
                               const swift::SourceLoc)
         {
+            //NOTE(sasha): We don't use normal logging system here because we always
+            //             want to show compiler errors.
             std::string diagnostic;
             llvm::raw_string_ostream stream(diagnostic);
             swift::DiagnosticEngine::formatDiagnosticText(stream, fmt_str, fmt_args);
             stream.flush();
-            std::cout << "Received Diagnostic: " << diagnostic << std::endl;
+            std::cout << diagnostic << std::endl;
         }
     };
     

--- a/main.cpp
+++ b/main.cpp
@@ -1,10 +1,12 @@
 #include <iostream>
 #include <string>
 
+#include "CommandLineOptions.h"
 #include "REPL.h"
 
 int main(int argc, char **argv)
 {
+    ParseCommandLineOptions(argc, argv);
     std::string line;
     REPL repl;
     do

--- a/main.cpp
+++ b/main.cpp
@@ -4,9 +4,16 @@
 #include "CommandLineOptions.h"
 #include "REPL.h"
 
+void SetupOptions(int argc, char **argv)
+{
+    CommandLineOptions opts = ParseCommandLineOptions(argc, argv);
+    SetLoggingOptions(opts.logging_opts);
+}
+
 int main(int argc, char **argv)
 {
-    ParseCommandLineOptions(argc, argv);
+    SetupOptions(argc, argv);
+
     std::string line;
     REPL repl;
     do


### PR DESCRIPTION
Adds command line parsing and a logging system. You can now modify what types of logs you see from the command line, and it defaults to showing all logs. Logs come in three priorities: Info, Warning, and Error. Different areas of the code have an associated area in the enum. You can specify which areas to receive logs from. 
An example invocation of could be `swift-repl.exe --logging=ast --logging_priority=warning`. This will show  everything involving the AST that prints with priority Warning or higher (i.e. Warning and Error, but not Info). 