### PR TITLE
Compile integer expressions

### DIFF
--- a/JIT.cpp
+++ b/JIT.cpp
@@ -1,4 +1,5 @@
 #include "JIT.h"
+#include "Logging.h"
 
 llvm::Expected<std::unique_ptr<JIT>> JIT::Create()
 {
@@ -13,14 +14,16 @@ llvm::Expected<std::unique_ptr<JIT>> JIT::Create()
     return std::unique_ptr<JIT>(new JIT(std::move(*machine_builder), std::move(*data_layout)));
 }
 
-llvm::Error JIT::AddModule(std::unique_ptr<llvm::Module> module)
+void JIT::AddModule(std::unique_ptr<llvm::Module> module)
 {
-    return m_compile_layer.add(m_execution_session.getMainJITDylib(),
-                               orc::ThreadSafeModule(std::move(module), m_ctx));
+    llvm::cantFail(m_compile_layer.add(m_execution_session.getMainJITDylib(),
+                                       orc::ThreadSafeModule(std::move(module), m_ctx)));
 }
 
 llvm::Expected<llvm::JITEvaluatedSymbol> JIT::LookupSymbol(llvm::StringRef symbol_name)
 {
+    SetCurrentLoggingArea(LoggingArea::JIT);
+    Log(std::string("Looking up symbol ") + symbol_name.str());
     return m_execution_session.lookup({ &m_execution_session.getMainJITDylib() },
                                       m_mangler(symbol_name.str()));
 }
@@ -35,9 +38,13 @@ JIT::JIT(orc::JITTargetMachineBuilder machine_builder,
                                          m_mangler(m_execution_session, m_data_layout),
                                          m_ctx(std::make_unique<llvm::LLVMContext>())
 {
+    static bool s_run_guard = false;
+    if(!s_run_guard)
+    {
+        s_run_guard = true;
+        llvm::sys::DynamicLibrary::LoadLibraryPermanently("S:\\b\\swift\\bin\\swiftCore.dll");
+    }
+
     m_execution_session.getMainJITDylib().setGenerator(
         llvm::cantFail(orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(data_layout)));
 }
-
-
-

--- a/JIT.h
+++ b/JIT.h
@@ -16,7 +16,7 @@ class JIT
 {
 public:
     static llvm::Expected<std::unique_ptr<JIT>> Create();
-    llvm::Error AddModule(std::unique_ptr<llvm::Module> module);
+    void AddModule(std::unique_ptr<llvm::Module> module);
     llvm::Expected<llvm::JITEvaluatedSymbol> LookupSymbol(llvm::StringRef symbol_name);
 
 private:

--- a/Logging.cpp
+++ b/Logging.cpp
@@ -29,7 +29,7 @@ LoggingArea &operator |=(LoggingArea &l, LoggingArea r)
 LoggingOptions g_log_opts;
 LoggingArea g_curr_logging_area;
 
-const char *PriorityStrings[] = { "", "[INFO] ", "[WARNING ]", "[ERROR] " };
+const char *PriorityStrings[] = { "[INFO] ", "[WARNING] ", "[ERROR] ", "", "" };
 
 void SetLoggingOptions(LoggingOptions opts)
 {

--- a/REPL.h
+++ b/REPL.h
@@ -22,9 +22,12 @@
 
 struct REPL
 {
-    REPL();
+    static llvm::Expected<std::unique_ptr<REPL>> Create();
     bool IsExitString(const std::string &line);
     bool ExecuteSwift(std::string line);
+
+protected:
+    REPL();
 
 private:
     struct ReplInput

--- a/TransformAST.cpp
+++ b/TransformAST.cpp
@@ -80,20 +80,15 @@ void WrapInFunction(swift::SourceFile &src_file)
             nullptr, // GenericParams
             empty_params_list, // BodyParams
             swift::TypeLoc(), // ReturnType should be void
-            last_top_level_code_decl); // Parent
+            last_top_level_code_decl->getParent()); // Parent
+        new_func->setInterfaceType(swift::FunctionType::get({}, ast_ctx.TheEmptyTupleType, {}));
 
         swift::BraceStmt *fn_body = swift::BraceStmt::create(
             ast_ctx, swift::SourceLoc(), old_top_level_body->getElements(),
             swift::SourceLoc(), true);
 
         new_func->setBody(fn_body);
-
-        swift::BraceStmt *new_top_level_body = swift::BraceStmt::create(
-             ast_ctx, fn_start,
-             llvm::ArrayRef<swift::ASTNode>(new_func),
-             fn_end, true);
-
-        last_top_level_code_decl->setBody(new_top_level_body);
+        src_file.Decls.back() = new_func;
     }
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -14,11 +14,22 @@ int main(int argc, char **argv)
 {
     SetupOptions(argc, argv);
 
+    llvm::Expected<std::unique_ptr<REPL>> repl = REPL::Create();
+    if(!repl)
+    {
+        std::string err_str;
+        llvm::raw_string_ostream stream(err_str);
+        stream << repl.takeError();
+        stream.flush();
+        SetCurrentLoggingArea(LoggingArea::All);
+        Log(err_str, LoggingPriority::Error);
+        return 1;
+    }
+
     std::string line;
-    REPL repl;
     do
     {
         std::getline(std::cin, line);
-    } while(repl.ExecuteSwift(line));
+    } while((*repl)->ExecuteSwift(line));
     return 0;
 }


### PR DESCRIPTION
Compiles and runs expressions that return integers. Doubles also work, but you'll get the integer representation of the double. To actually run this successfully, you need a small patch on LLVM that I'll hopefully get merged soon. 