### PR TITLE
Insert call to print() as final statement

### DIFF
--- a/REPL.h
+++ b/REPL.h
@@ -23,6 +23,7 @@
 struct REPL
 {
     static llvm::Expected<std::unique_ptr<REPL>> Create();
+    std::string GetLine();
     bool IsExitString(const std::string &line);
     bool ExecuteSwift(std::string line);
 
@@ -64,7 +65,9 @@ private:
             std::cout << diagnostic << std::endl;
         }
     };
-    
+
+    uint64_t m_curr_input_number;
+
     swift::CompilerInvocation m_invocation;
     
     swift::LangOptions m_lang_opts;

--- a/main.cpp
+++ b/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv)
     std::string line;
     do
     {
-        std::getline(std::cin, line);
+        line = (*repl)->GetLine();
     } while((*repl)->ExecuteSwift(line));
     return 0;
 }


### PR DESCRIPTION
Also runs diagnostic pass on generated SIL which mysteriously removes
destructure_tuple instructions which cause IR generation to fail.