### PR TITLE
Allow redefinitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(swift-repl
   REPL.cpp
   JIT.cpp
   TransformAST.cpp
+  TransformIR.cpp
   CommandLineOptions.cpp
   Logging.cpp)
 target_include_directories(swift-repl PRIVATE ${SWIFT_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})

--- a/JIT.cpp
+++ b/JIT.cpp
@@ -23,9 +23,16 @@ void JIT::AddModule(std::unique_ptr<llvm::Module> module)
 llvm::Expected<llvm::JITEvaluatedSymbol> JIT::LookupSymbol(llvm::StringRef symbol_name)
 {
     SetCurrentLoggingArea(LoggingArea::JIT);
-    Log(std::string("Looking up symbol ") + symbol_name.str());
+    Log((llvm::Twine("Looking up symbol ") + symbol_name).str());
     return m_execution_session.lookup({ &m_execution_session.getMainJITDylib() },
                                       m_mangler(symbol_name.str()));
+}
+
+llvm::Error JIT::RemoveSymbol(llvm::StringRef symbol_name)
+{
+    SetCurrentLoggingArea(LoggingArea::JIT);
+    Log(std::string("Removing symbol ") + symbol_name.str());
+    return m_execution_session.getMainJITDylib().remove({ m_execution_session.intern(symbol_name.str()) });
 }
 
 JIT::JIT(orc::JITTargetMachineBuilder machine_builder,

--- a/JIT.h
+++ b/JIT.h
@@ -18,6 +18,10 @@ public:
     static llvm::Expected<std::unique_ptr<JIT>> Create();
     void AddModule(std::unique_ptr<llvm::Module> module);
     llvm::Expected<llvm::JITEvaluatedSymbol> LookupSymbol(llvm::StringRef symbol_name);
+    // NOTE(sasha): Returns SymbolsNotFound Error if the symbol was not found
+    //              Returns SymbolsCouldNotBeRemoved on failure to actually remove the symbol
+    //              Returns Error::success() on success, does nothing on failure.
+    llvm::Error RemoveSymbol(llvm::StringRef symbol_name);
 
 private:
     JIT(orc::JITTargetMachineBuilder machine_builder, llvm::DataLayout data_layout);

--- a/REPL.h
+++ b/REPL.h
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <string>
+#include <unordered_map>
 
 #include <llvm/IR/Module.h>
 
@@ -22,13 +23,13 @@
 
 struct REPL
 {
-    static llvm::Expected<std::unique_ptr<REPL>> Create();
+    static llvm::Expected<std::unique_ptr<REPL>> Create(bool is_playground = false);
     std::string GetLine();
     bool IsExitString(const std::string &line);
     bool ExecuteSwift(std::string line);
 
 protected:
-    REPL();
+    explicit REPL(bool is_playground);
 
 private:
     struct ReplInput
@@ -38,6 +39,7 @@ private:
         std::string text;
     };
 
+    llvm::Optional<std::unique_ptr<llvm::Module>> CompileSourceFileToIR(swift::SourceFile &src_file);
     void ModifyAST(swift::SourceFile &src_file);
     ReplInput AddToSrcMgr(const std::string &line);
     void SetupLangOpts();
@@ -66,6 +68,7 @@ private:
         }
     };
 
+    const bool m_is_playground;
     uint64_t m_curr_input_number;
 
     swift::CompilerInvocation m_invocation;
@@ -81,6 +84,8 @@ private:
 
     std::unique_ptr<swift::ASTContext> m_ast_ctx;
 
+    using DeclMap = std::unordered_map<std::string, swift::SourceFile *>;
+    DeclMap m_decl_map;
     std::vector<swift::Identifier> m_modules;
 
     std::unique_ptr<JIT> m_jit;

--- a/REPL.h
+++ b/REPL.h
@@ -39,7 +39,9 @@ private:
         std::string text;
     };
 
-    llvm::Optional<std::unique_ptr<llvm::Module>> CompileSourceFileToIR(swift::SourceFile &src_file);
+    void RemoveRedeclarationsFromJIT(std::unique_ptr<llvm::Module> &sil_module);
+    llvm::Error UpdateFunctionPointers();
+    bool CompileSourceFileToIRAndAddToJIT(swift::SourceFile &src_file);
     void ModifyAST(swift::SourceFile &src_file);
     ReplInput AddToSrcMgr(const std::string &line);
     void SetupLangOpts();
@@ -47,7 +49,7 @@ private:
     void SetupSILOpts();
     void SetupIROpts();
     void SetupImporters();
-    
+
     class PrinterDiagnosticConsumer : public swift::DiagnosticConsumer
     {
         void handleDiagnostic(swift::SourceManager &src_mgr,
@@ -86,6 +88,7 @@ private:
 
     using DeclMap = std::unordered_map<std::string, swift::SourceFile *>;
     DeclMap m_decl_map;
+    std::unordered_map<std::string, std::string> m_fn_ptr_map;
     std::vector<swift::Identifier> m_modules;
 
     std::unique_ptr<JIT> m_jit;

--- a/TransformIR.cpp
+++ b/TransformIR.cpp
@@ -1,0 +1,122 @@
+#include "TransformIR.h"
+#include "Logging.h"
+
+#include <algorithm>
+
+#include <llvm/IR/Instructions.h>
+
+#define FN_PTR_SUFFIX "_ptr"
+
+void AddFunctionPointers(std::unique_ptr<llvm::Module> &llvm_module,
+                         std::unique_ptr<JIT> &jit,
+                         llvm::LLVMContext &llvm_ctx,
+                         std::unordered_map<std::string, std::string> &fn_ptr_map)
+{
+    auto ptr_module = std::make_unique<llvm::Module>("fn_ptrs", llvm_ctx);
+    for(auto &fn : llvm_module->getFunctionList())
+    {
+        assert(fn.hasExternalLinkage());
+
+        std::string fn_name = fn.getName().str();
+        std::string ptr_name = fn_name + FN_PTR_SUFFIX;
+        if(fn_ptr_map.find(fn_name) == fn_ptr_map.end())
+            continue;
+
+        if(fn_ptr_map[fn_name].empty())
+        {
+            llvm::Type *ptr_type = llvm::Type::getInt8PtrTy(llvm_ctx);
+            llvm::GlobalVariable *ptr = new llvm::GlobalVariable(*ptr_module,
+                                                                 ptr_type,
+                                                                 false,
+                                                                 llvm::GlobalValue::LinkageTypes::ExternalLinkage,
+                                                                 llvm::Constant::getNullValue(ptr_type),
+                                                                 ptr_name);
+            fn_ptr_map[fn_name] = ptr_name;
+        }
+        assert(fn_ptr_map[fn_name] == ptr_name);
+    }
+    jit->AddModule(std::move(ptr_module));
+}
+
+void ReplaceFunctionCallsWithIndirectFunctionCalls(
+    llvm::Instruction &i, std::unique_ptr<llvm::Module> &module,
+    llvm::LLVMContext &llvm_ctx,
+    std::unordered_map<std::string, std::string> &fn_ptr_map)
+{
+    SetCurrentLoggingArea(LoggingArea::IR);
+    auto *call_inst = llvm::dyn_cast<llvm::CallInst>(&i);
+    if(!call_inst)
+        return;
+
+    auto *called_fn = call_inst->getCalledFunction();
+    if(!called_fn)
+        return;
+
+    std::string fn_name = called_fn->getName().str();
+    if(fn_ptr_map.find(fn_name) == fn_ptr_map.end())
+        return;
+
+    std::string log_string;
+    llvm::raw_string_ostream str_stream(log_string);
+    str_stream << "Changed instruction:\n\t";
+    call_inst->print(str_stream);
+
+    std::string ptr_name = fn_ptr_map[fn_name];
+    auto *ptr = new llvm::GlobalVariable(
+        *module, llvm::Type::getInt8PtrTy(llvm_ctx),
+        false, llvm::GlobalValue::LinkageTypes::ExternalLinkage,
+        nullptr, ptr_name);
+
+    ptr->setDLLStorageClass(llvm::GlobalValue::DLLStorageClassTypes::DLLImportStorageClass);
+
+    auto *load = new llvm::LoadInst(ptr->getType()->getElementType(), ptr);
+    auto *bitcast = new llvm::BitCastInst(load, called_fn->getFunctionType()->getPointerTo(), "", call_inst);
+    load->insertBefore(bitcast);
+    call_inst->setCalledOperand(bitcast);
+
+    str_stream << "\nTo:\n\t";
+    load->print(str_stream);
+    str_stream << "\n\t";
+    bitcast->print(str_stream);
+    str_stream << "\n\t";
+    call_inst->print(str_stream);
+    str_stream << "\nAdded global:\n\t";
+    ptr->print(str_stream);
+    str_stream.flush();
+    Log(log_string);
+}
+
+void ReplaceFunctionCallsWithIndirectFunctionCalls(
+    llvm::BasicBlock &bb, std::unique_ptr<llvm::Module> &module,
+    llvm::LLVMContext &llvm_ctx,
+    std::unordered_map<std::string, std::string> &fn_ptr_map)
+{
+    std::for_each(bb.begin(), bb.end(),
+                  [&](auto &i)
+                  {
+                      ReplaceFunctionCallsWithIndirectFunctionCalls(i, module, llvm_ctx, fn_ptr_map);
+                  });
+}
+
+void ReplaceFunctionCallsWithIndirectFunctionCalls(
+    llvm::Function &fn, std::unique_ptr<llvm::Module> &module,
+    llvm::LLVMContext &llvm_ctx,
+    std::unordered_map<std::string, std::string> &fn_ptr_map)
+{
+    std::for_each(fn.getBasicBlockList().begin(), fn.getBasicBlockList().end(),
+                  [&](auto &bb)
+                  {
+                      ReplaceFunctionCallsWithIndirectFunctionCalls(bb, module, llvm_ctx, fn_ptr_map);
+                  });
+}
+
+void ReplaceFunctionCallsWithIndirectFunctionCalls(
+    std::unique_ptr<llvm::Module> &module, llvm::LLVMContext &llvm_ctx,
+    std::unordered_map<std::string, std::string> &fn_ptr_map)
+{
+    std::for_each(module->getFunctionList().begin(), module->getFunctionList().end(),
+                  [&](auto &fn)
+                  {
+                      ReplaceFunctionCallsWithIndirectFunctionCalls(fn, module, llvm_ctx, fn_ptr_map);
+                  });
+}

--- a/TransformIR.h
+++ b/TransformIR.h
@@ -1,0 +1,22 @@
+#ifndef TRANSFORMIR_H
+#define TRANSFORMIR_H
+
+#include "JIT.h"
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+#include <llvm/IR/Module.h>
+
+// Adds the function pointers to the JIT corresponding to functions in fn_ptr_map that have
+// an empty pointer name
+void AddFunctionPointers(
+    std::unique_ptr<llvm::Module> &module, std::unique_ptr<JIT> &jit,
+    llvm::LLVMContext &llvm_ctx,
+    std::unordered_map<std::string, std::string> &fn_ptr_map);
+
+void ReplaceFunctionCallsWithIndirectFunctionCalls(
+    std::unique_ptr<llvm::Module> &module, llvm::LLVMContext &llvm_ctx,
+    std::unordered_map<std::string, std::string> &fn_ptr_map);
+#endif


### PR DESCRIPTION
Allow function redefinitions in REPL mode (not playground mode). This changes every reference to a function into an indirect call that allows the function to be swapped out when recompiled. No redefinitions of any kind are allowed in playground mode. 