### PR TITLE
Add testing infrastructure using LLVM LIT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/*
+tests/lit.cfg.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ find_package(LLVM CONFIG REQUIRED)
 find_package(Swift CONFIG REQUIRED)
 find_package(Clang CONFIG REQUIRED)
 
+set(SwiftREPL_TESTS_DIR ${CMAKE_SOURCE_DIR}/tests)
+
+configure_file(${SwiftREPL_TESTS_DIR}/lit.cfg.py.in ${SwiftREPL_TESTS_DIR}/lit.cfg.py)
+configure_file(test.py.in test.py)
+
 add_executable(swift-repl
   main.cpp
   REPL.cpp

--- a/CommandLineOptions.cpp
+++ b/CommandLineOptions.cpp
@@ -44,6 +44,17 @@ void SetLoggingPriorityOption(std::string opt, std::string val, CommandLineOptio
         opts.logging_opts.min_priority = priority;
 }
 
+void SetPlaygroundOption(std::string opt, std::string val, CommandLineOptions &opts)
+{
+    int is_playground = llvm::StringSwitch<int>(val)
+        .Case("true", 1)
+        .Case("false", 0)
+        .Default(-1);
+    if(is_playground == -1)
+        std::cout << "[Warning] is_playground is neither \"true\" nor \"false\". Defaulting to \"false\"\n";
+    opts.is_playground = is_playground == 1;
+}
+
 void ParseSingleCommandLineOption(std::string arg, CommandLineOptions &opts)
 {
     using OptionParseFn = std::add_pointer<void(std::string, std::string, CommandLineOptions &)>::type;
@@ -53,6 +64,7 @@ void ParseSingleCommandLineOption(std::string arg, CommandLineOptions &opts)
     llvm::StringSwitch<OptionParseFn>(opt)
         .Case("--logging", SetLoggingAreaOption)
         .Case("--logging_priority", SetLoggingPriorityOption)
+        .Case("--playground", SetPlaygroundOption)
         .Default(HandleUnknownOption)
         (opt, val, opts);
 }

--- a/CommandLineOptions.h
+++ b/CommandLineOptions.h
@@ -6,6 +6,7 @@
 struct CommandLineOptions
 {
     LoggingOptions logging_opts;
+    bool is_playground;
 };
 
 CommandLineOptions ParseCommandLineOptions(int argc, char **argv);

--- a/main.cpp
+++ b/main.cpp
@@ -4,17 +4,18 @@
 #include "CommandLineOptions.h"
 #include "REPL.h"
 
-void SetupOptions(int argc, char **argv)
+CommandLineOptions SetupOptions(int argc, char **argv)
 {
     CommandLineOptions opts = ParseCommandLineOptions(argc, argv);
     SetLoggingOptions(opts.logging_opts);
+    return opts;
 }
 
 int main(int argc, char **argv)
 {
-    SetupOptions(argc, argv);
+    CommandLineOptions opts = SetupOptions(argc, argv);
 
-    llvm::Expected<std::unique_ptr<REPL>> repl = REPL::Create();
+    llvm::Expected<std::unique_ptr<REPL>> repl = REPL::Create(opts.is_playground);
     if(!repl)
     {
         std::string err_str;

--- a/test.py.in
+++ b/test.py.in
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+import os
+import sys
+llvm_lit = os.path.join('@LLVM_TOOLS_BINARY_DIR@', 'llvm-lit.py')
+sys.argv = [llvm_lit, '@SwiftREPL_TESTS_DIR@', '-v', '-vv']
+execfile(llvm_lit)

--- a/tests/lit.cfg.py.in
+++ b/tests/lit.cfg.py.in
@@ -1,0 +1,16 @@
+# -*- Python -*-
+
+import os
+import sys
+
+import lit.util
+import lit.formats
+
+config.name = 'Swift REPL'
+config.test_format = lit.formats.ShTest()
+config.test_source_root = os.path.dirname(__file__)
+config.suffixes = ['.test']
+config.substitutions = [
+    ('%swift-repl', os.path.join('@CMAKE_BINARY_DIR@', 'swift-repl.exe')),
+    ('%FileCheck', os.path.join('@LLVM_BINARY_DIR@', 'bin', 'FileCheck.exe')),
+]

--- a/tests/test_basic.test
+++ b/tests/test_basic.test
@@ -1,0 +1,10 @@
+# RUN: cat %s | %swift-repl --logging_priority=none | %FileCheck %s
+1+1
+2+2
+"HI"
+(a: 5, b: 6)
+e
+# CHECK: 2
+# CHECK: 4
+# CHECK: HI
+# CHECK: (a: 5, b: 6)

--- a/tests/test_classes.test
+++ b/tests/test_classes.test
@@ -1,0 +1,15 @@
+# RUN: cat %s | %swift-repl --logging_priority=none | %FileCheck %s
+class A { var x: Int; public init(x: Int) { self.x = x }; func inc() { x += 1 } }
+var a = A(x: 5)
+a.x
+a.inc()
+a.x
+a.inc()
+a.x
+a.inc()
+a.x
+e
+# CHECK: 5
+# CHECK: 6
+# CHECK: 7
+# CHECK: 8

--- a/tests/test_functions_playground.test
+++ b/tests/test_functions_playground.test
@@ -1,0 +1,14 @@
+# RUN: cat %s | %swift-repl --logging_priority=none --playground=true | %FileCheck %s
+func a() -> Int { return 5 }
+a()
+func b() { print(a()) }
+b()
+func a() -> Int { return 10 }
+a()
+b()
+e
+# CHECK: 5
+# CHECK: 5
+# CHECK: Invalid redeclaration of a
+# CHECK: 5
+# CHECK: 5

--- a/tests/test_functions_repl.test
+++ b/tests/test_functions_repl.test
@@ -1,0 +1,13 @@
+# RUN: cat %s | %swift-repl --logging_priority=none --playground=false | %FileCheck %s
+func a() -> Int { return 5 }
+a()
+func b() { print(a()) }
+b()
+func a() -> Int { return 10 }
+a()
+b()
+e
+# CHECK: 5
+# CHECK: 5
+# CHECK: 10
+# CHECK: 10

--- a/tests/test_variables.test
+++ b/tests/test_variables.test
@@ -1,0 +1,17 @@
+# RUN: cat %s | %swift-repl --logging_priority=none | %FileCheck %s
+let a = 5
+a
+let b : UInt = 10
+b
+var c = 0
+c
+c += 1
+c
+c += 1
+c
+e
+# CHECK: 5
+# CHECK: 10
+# CHECK: 0
+# CHECK: 1
+# CHECK: 2


### PR DESCRIPTION
Adds testing infrastructure! After running CMake, you should just be able to run `test.py` to run all of the tests. 