### PR TITLE
Add Support for Loading Frameworks

### DIFF
--- a/CommandLineOptions.cpp
+++ b/CommandLineOptions.cpp
@@ -80,6 +80,8 @@ void HandleOptionWithoutEquals(std::string arg, CommandLineOptions &opts)
         opts.include_paths.push_back(arg.substr(2));
     else if(StartsWith(arg, "-L"))
         opts.link_paths.push_back(arg.substr(2));
+    else if(StartsWith(arg, "-F"))
+        opts.framework_paths.push_back(arg.substr(2));
     else if(arg == "--print_to_console")
         opts.print_to_console = true;
     else

--- a/CommandLineOptions.h
+++ b/CommandLineOptions.h
@@ -14,6 +14,7 @@ struct CommandLineOptions
     std::string default_module_cache_path;
     std::vector<std::string> include_paths;
     std::vector<std::string> link_paths;
+    std::vector<std::string> framework_paths;
 };
 
 CommandLineOptions ParseCommandLineOptions(int argc, char **argv);

--- a/REPL.cpp
+++ b/REPL.cpp
@@ -119,6 +119,11 @@ void REPL::AddModuleSearchPath(std::string path)
     m_ast_ctx->addSearchPath(path, false, false);
 }
 
+void REPL::AddFrameworkSearchPath(std::string path)
+{
+    m_ast_ctx->addSearchPath(path, true, false);
+}
+
 void REPL::AddLoadSearchPath(std::string path)
 {
     m_jit->AddSearchPath(path);

--- a/REPL.h
+++ b/REPL.h
@@ -29,6 +29,7 @@ struct REPL
         std::string default_module_cache_path = DEFAULT_MODULE_CACHE_PATH);
     std::string GetLine();
     void AddModuleSearchPath(std::string path);
+    void AddFrameworkSearchPath(std::string path);
     void AddLoadSearchPath(std::string path);
     bool IsExitString(const std::string &line);
     bool ExecuteSwift(std::string line);

--- a/swift-playground.cpp
+++ b/swift-playground.cpp
@@ -233,6 +233,8 @@ void Playground::ResetREPL()
                   [&](auto s) { (*repl)->AddModuleSearchPath(s); });
     std::for_each(g_opts.link_paths.begin(), g_opts.link_paths.end(),
                   [&](auto s) { (*repl)->AddLoadSearchPath(s); });
+    std::for_each(g_opts.framework_paths.begin(), g_opts.framework_paths.end(),
+                  [&](auto s) { (*repl)->AddFrameworkSearchPath(s); });
 
     m_repl = std::move(*repl);
 }

--- a/swift-repl.cpp
+++ b/swift-repl.cpp
@@ -26,6 +26,8 @@ std::unique_ptr<REPL> SetupREPLWithOptions(int argc, char **argv)
                   [&](auto s) { (*repl)->AddModuleSearchPath(s); });
     std::for_each(opts.link_paths.begin(), opts.link_paths.end(),
                   [&](auto s) { (*repl)->AddLoadSearchPath(s); });
+    std::for_each(opts.framework_paths.begin(), opts.framework_paths.end(),
+                  [&](auto s) { (*repl)->AddFrameworkSearchPath(s); });
     return std::move(*repl);
 }
 


### PR DESCRIPTION
I'd like to load swift-corelibs-foundation and CoreFoundation which is
distributed as a framework.

```
C:\Users\gwenm\local\swift-repl\build ▶  .\swift-repl.exe \
-IS:\b\foundation\swift -LS:\b\foundation -FS:\b\foundation \
-IS:\b\libdispatch\src\swift  -IS:\b\libdispatch\src \
-IS:\b\swift-libdispatch-prefix\include \
-IS:\swift-corelibs-libdispatch \
-LS:\b\libdispatch\src -LS:\b\libdispatch \

1> import Foundation

2> NSHomeDirectory()
C:/Users/gwenm

3>
```